### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MiguelElGallo/ghs/security/code-scanning/1](https://github.com/MiguelElGallo/ghs/security/code-scanning/1)

To fix the problem, you should add a `permissions:` block to the workflow so that the GITHUB_TOKEN used by Actions jobs is restricted to minimal required privileges. In this case, the test job only checks out code and runs tests, which requires only `contents: read`. You can add this block either at the root level of the workflow YAML (so it affects all jobs unless overridden), or within the `test` job itself. The most robust and future-proof fix is to set it globally at the root of the workflow, just after `name:` (before `on:`), with the value:
```yaml
permissions:
  contents: read
```
No new imports, methods, or other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
